### PR TITLE
Update MainWindow.xaml.cs

### DIFF
--- a/Code/Chapter_1/MatchGame/MatchGame/MainWindow.xaml.cs
+++ b/Code/Chapter_1/MatchGame/MatchGame/MainWindow.xaml.cs
@@ -77,6 +77,14 @@ namespace MatchGame
             timer.Start();
             tenthsOfSecondsElapsed = 0;
             matchesFound = 0;
+            
+            foreach (TextBlock textBlock in mainGrid.Children.OfType<TextBlock>()) // after replay, meke them visible again
+            {
+                if (textBlock.Name != "timeTextBlock")
+                {
+                    textBlock.Visibility = Visibility.Visible;
+                }
+            }
         }
 
         TextBlock lastTextBlockClicked;


### PR DESCRIPTION
When the player completes the  first game and clicks on 'Play Again?' the timer re-starts, but the emojis are not visible.
I have added a for each loop at the end of SetUpGame to change its visibility again to visible. It does it even the first time the game
it is played, but it does not matter much.
Note: I am a student and this is the first time I use GitHub, so I hope I do it right :)